### PR TITLE
fix(package): change `main` field to fix prebundle tool like snowpack

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,5 +1,0 @@
-Path = require 'path'
-
-module.exports = switch Path.extname __filename
-  when '.coffee' then require './src/monkey'
-  else require './lib/monkey'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "email": "contact@devicefarmer.com",
     "url": "https://devicefarmer.com/"
   },
-  "main": "./index",
+  "main": "./lib/monkey.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/DeviceFarmer/adbkit-monkey.git"


### PR DESCRIPTION
change the package entry to the javascript file to fix pre bundle tools like `snowpack` or `webpack` build issue

My scenario is:

I'm trying to build an electron app with `snowpack`. In the `main` thread to communicate with Android phones. And I found the awesome package you made [@devicefarmer/adbkit](https://github.com/DeviceFarmer/adbkit).
So I install it in my app but the bundle tool cannot find `require './src/monkey'` in `index.js` because the `src` folder was ignored in the publishing stage.

So I made the change to fix the scenario like this. and I believe many users will face this issue like me. not everyone calls ADB in node runtime.

PS: I'm not an English native speaker. please feel free to edit this issue. And I hope you can understand what I'm talking 😂